### PR TITLE
Make activate script safe for use with `set -o nounset`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set name = "openjdk" %}
 {% set version = "8.0.144" %}
 {% set zulu_build = "8.23.0.3" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set sha256_linux = "7e6284739c0e5b7142bc7a9adc61ced70dc5bb26b130b582b18e809013bcb251" %}
 {% set sha256_osx = "ff533364c9cbd3b271ab5328efe28e2dd6d7bae5b630098a5683f742ecf0709d" %}
 {% set sha256_win = "f1d9d3341ef7c8c9baff3597953e99a6a7c64f8608ee62c03fdd7574b7655c02" %}

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,7 +1,7 @@
-export JAVA_HOME_CONDA_BACKUP=$JAVA_HOME
+export JAVA_HOME_CONDA_BACKUP=${JAVA_HOME:-}
 export JAVA_HOME=$CONDA_PREFIX
 
-export JAVA_LD_LIBRARY_PATH_BACKUP=$JAVA_LD_LIBRARY_PATH
+export JAVA_LD_LIBRARY_PATH_BACKUP=${JAVA_LD_LIBRARY_PATH:-}
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 if [[ $os == 'darwin' ]]; then


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This script fails if you run `set -o nounset` (aka `set -u`) before running it when either JAVA_HOME or JAVA_LD_LIBRARY_PATH are not set in the environment (errors like `-bash: JAVA_HOME: unbound variable`).

This change uses a default null value if those environment variables are not set, making it safe for use after `set -o nounset` without changing the functionality.