### PR TITLE
Fix Windows Java paths and and Bash activation scripts during install…

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,16 +9,19 @@ if errorlevel 1 exit 1
 XCOPY lib\* %LIBRARY_LIB% /s /i /y
 if errorlevel 1 exit 1
 
-XCOPY DISCLAIMER %PREFIX% /s /i /y
+XCOPY DISCLAIMER %LIBRARY_PREFIX% /s /i /y
 if errorlevel 1 exit 1
 
-XCOPY conf\* %PREFIX% /s /i /y
+if not exist "%LIBRARY_PREFIX%\conf\" mkdir %LIBRARY_PREFIX%\conf\
+XCOPY conf\* %LIBRARY_PREFIX%\conf\ /s /i /y
 if errorlevel 1 exit 1
 
-XCOPY jmods\* %PREFIX% /s /i /y
+if not exist "%LIBRARY_PREFIX%\jmods\" mkdir %LIBRARY_PREFIX%\jmods\
+XCOPY jmods\* %LIBRARY_PREFIX%\jmods\ /s /i /y
 if errorlevel 1 exit 1
 
-XCOPY legal\* %PREFIX% /s /i /y
+if not exist "%LIBRARY_PREFIX%\legal\" mkdir %LIBRARY_PREFIX%\legal\
+XCOPY legal\* %LIBRARY_PREFIX%\legal\ /s /i /y
 if errorlevel 1 exit 1
 
 :: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
@@ -27,5 +30,8 @@ FOR %%F IN (activate deactivate) DO (
     if not exist %PREFIX%\etc\conda\%%F.d MKDIR %PREFIX%\etc\conda\%%F.d
     if errorlevel 1 exit 1
     copy %RECIPE_DIR%\scripts\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    :: We also copy .sh scripts to be able to use them
+    :: with POSIX CLI on Windows.
+    copy %RECIPE_DIR%\scripts\%%F.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
     if errorlevel 1 exit 1
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "openjdk" %}
 {% set version = "11.0.1" %}
 {% set zulu_build = "11.2.3" %}
-{% set build_number = 1002 %}
+{% set build_number = 1003 %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 
-if [ "${JAVA_HOME}" != "${PREFIX}" ]; then
-  echo "ERROR: JAVA_HOME (${JAVA_HOME}) not equal to PREFIX (${PREFIX})"
-  exit 1
+if [[ $(uname -s) == CYGWIN* ]] || [[ $(uname -s) =~ M* ]];
+then
+    # Windows
+    if [ "${JAVA_HOME}" != "${PREFIX}/Library" ]; then
+      echo "ERROR: JAVA_HOME (${JAVA_HOME}) not equal to PREFIX (${PREFIX}/Library)"
+      exit 1
+    fi
+
+else 
+    # Linux / OSX
+   if [ "${JAVA_HOME}" != "${PREFIX}" ]; then
+     echo "ERROR: JAVA_HOME (${JAVA_HOME}) not equal to PREFIX (${PREFIX})"
+     exit 1
+   fi
 fi
 
 pushd test-nio

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,5 +1,14 @@
-export JAVA_HOME_CONDA_BACKUP=${JAVA_HOME:-}
-export JAVA_HOME=$CONDA_PREFIX
+if [[ $(uname -s) == CYGWIN* ]] || [[ $(uname -s) =~ M* ]];
+then
+    # Windows
+    export JAVA_HOME_CONDA_BACKUP=${JAVA_HOME:-}
+    export JAVA_HOME=$CONDA_PREFIX/Library
 
-export JAVA_LD_LIBRARY_PATH_BACKUP=${JAVA_LD_LIBRARY_PATH:-}
-export JAVA_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
+else 
+    # Linux / OSX
+    export JAVA_HOME_CONDA_BACKUP=${JAVA_HOME:-}
+    export JAVA_HOME=$CONDA_PREFIX
+
+    export JAVA_LD_LIBRARY_PATH_BACKUP=${JAVA_LD_LIBRARY_PATH:-}
+    export JAVA_LD_LIBRARY_PATH=$JAVA_HOME/lib/server
+fi

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,11 +1,23 @@
-export JAVA_HOME=$JAVA_HOME_CONDA_BACKUP
-unset JAVA_HOME_CONDA_BACKUP
-if [ -z $JAVA_HOME ]; then
-	unset JAVA_HOME
-fi
+if [[ $(uname -s) == CYGWIN* ]] || [[ $(uname -s) =~ M* ]];
+then
+    # Windows
+    export JAVA_HOME=$JAVA_HOME_CONDA_BACKUP
+    unset JAVA_HOME_CONDA_BACKUP
+    if [ -z $JAVA_HOME ]; then
+        unset JAVA_HOME
+    fi
 
-export JAVA_LD_LIBRARY_PATH=$JAVA_LD_LIBRARY_PATH_BACKUP
-unset JAVA_LD_LIBRARY_PATH_BACKUP
-if [ -z $JAVA_LD_LIBRARY_PATH ]; then
-	unset JAVA_LD_LIBRARY_PATH
+else 
+    # Linux / OSX
+    export JAVA_HOME=$JAVA_HOME_CONDA_BACKUP
+    unset JAVA_HOME_CONDA_BACKUP
+    if [ -z $JAVA_HOME ]; then
+        unset JAVA_HOME
+    fi
+
+    export JAVA_LD_LIBRARY_PATH=$JAVA_LD_LIBRARY_PATH_BACKUP
+    unset JAVA_LD_LIBRARY_PATH_BACKUP
+    if [ -z $JAVA_LD_LIBRARY_PATH ]; then
+        unset JAVA_LD_LIBRARY_PATH
+    fi
 fi


### PR DESCRIPTION
The package was broken on Windows: https://github.com/conda-forge/pyimagej-feedstock/pull/3#issuecomment-445410704

I have also added `.sh` activation scripts during Windows installation so activation works on Windows when using a POSIX shell.