### PR TITLE
Use bash for activation and deactivation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "openjdk" %}
 {% set version = "8.0.192" %}
 {% set zulu_build = "8.33.0.1" %}
-{% set build_number = 1002 %}
+{% set build_number = 1003 %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export JAVA_HOME_CONDA_BACKUP=${JAVA_HOME:-}
 export JAVA_HOME=$CONDA_PREFIX
 

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export JAVA_HOME=$JAVA_HOME_CONDA_BACKUP
 unset JAVA_HOME_CONDA_BACKUP
 if [ -z $JAVA_HOME ]; then


### PR DESCRIPTION
Otherwise, the script might run with a shell not supporting the double bracket (`[[`) syntax. For example, when activating the conda environment on Travis CI in an Ubuntu environment, `/bin/dash` is used instead of `/bin/bash`, resulting in an error like:

```
.../etc/conda/activate.d/openjdk_activate.sh: [[: not found
```

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

I am rather new to conda-forge, so was not sure about the re-rendering step. From what I gleaned in the docs, this change does not warrant a re-render?