### PR TITLE
updated version from 11.0.9 to 11.0.15

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -16,45 +16,27 @@ jobs:
     CONDA_BLD_PATH: D:\\bld\\
 
   steps:
-    - script: |
-        choco install vcpython27 -fdv -y --debug
-      condition: contains(variables['CONFIG'], 'vs2008')
-      displayName: Install vcpython27.msi (if needed)
-
-    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
-    # - script: rmdir C:\cygwin /s /q
-    #   continueOnError: true
-
-    - powershell: |
-        Set-PSDebug -Trace 1
-
-        $batchcontent = @"
-        ECHO ON
-        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
-
-        DIR "%vcpython%"
-
-        CALL "%vcpython%\vcvarsall.bat" %*
-        "@
-
-        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
-        $batchPath = "$batchDir" + "\vcvarsall.bat"
-        New-Item -Path $batchPath -ItemType "file" -Force
-
-        Set-Content -Value $batchcontent -Path $batchPath
-
-        Get-ChildItem -Path $batchDir
-
-        Get-ChildItem -Path ($batchDir + '\..')
-
-      condition: contains(variables['CONFIG'], 'vs2008')
-      displayName: Patch vs2008 (if needed)
-    - task: CondaEnvironment@1
+    - task: PythonScript@0
+      displayName: 'Download Miniforge'
       inputs:
-        packageSpecs: 'python=3.9 conda-build conda pip boa conda-forge-ci-setup=3' # Optional
-        installOptions: "-c conda-forge"
-        updateConda: true
-      displayName: Install conda-build and activate environment
+        scriptSource: inline
+        script: |
+          import urllib.request
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
+          urllib.request.urlretrieve(url, path)
+
+    - script: |
+        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
+      displayName: Install Miniforge
+
+    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
+      displayName: Add conda to PATH
+
+    - script: |
+        call activate base
+        mamba.exe install 'python=3.9' conda-build conda pip boa 'conda-forge-ci-setup=3' -c conda-forge --strict-channel-priority --yes
+      displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
       displayName: Set PYTHONUNBUFFERED
@@ -73,23 +55,12 @@ jobs:
       displayName: conda-forge build setup
     
 
-    # Special cased version setting some more things!
-    - script: |
-        call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
-      displayName: Build recipe (vs2008)
-      env:
-        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
-        PYTHONUNBUFFERED: 1
-      condition: contains(variables['CONFIG'], 'vs2008')
-
     - script: |
         call activate base
         conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
-      condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base

--- a/.ci_support/migrations/alsa_lib126.yaml
+++ b/.ci_support/migrations/alsa_lib126.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-alsa_lib:
-- 1.2.6
-migrator_ts: 1639542038.0768828

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/recipe/fix-arm.patch
+++ b/recipe/fix-arm.patch
@@ -1,5 +1,5 @@
---- src/hotspot/cpu/aarch64/icache_aarch64.hpp	2021-03-19 21:07:28.000000000 +0100
-+++ src/hotspot/cpu/aarch64/icache_aarch64.hpp	2021-03-19 21:08:10.000000000 +0100
+--- src/hotspot/os_cpu/linux_aarch64/icache_linux_aarch64.hpp	2022-04-19 15:38:30.000000000 -0400
++++ src/hotspot/os_cpu/linux_aarch64/icache_linux_aarch64.hpp	2022-04-19 15:39:12.000000000 -0400
 @@ -30,6 +30,10 @@
  // modifies code, part of the processor instruction cache potentially
  // has to be flushed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
   - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macosx_x64.zip  # [osx and x86_64]
     sha256: a7d68fdf46d88db8b3531035ec1153438b8e519faca0cafd871e6be511ce8be1  # [osx and x86_64]
    
-  - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macos_aarch64.zip  # [osx and arm64]
+  - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macosx_aarch64.zip  # [osx and arm64]
     sha256: 43fde6e8291b972146687363b2531dc6e0ba0b18a9f9d66bdad9b88de7403297  # [osx and arm64]
 
   - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-win_x64.zip  # [win64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,43 @@
 {% set name = "openjdk" %}
-{% set version = "11.0.9.1" %}
-{% set zulu_build = "11.43.55-ca" %}
-{% set zulu_build_arm64 = "11.43.1007-ca" %}
-{% set openjdk_revision = "1" %}
+{% set version = "11.0.15" %}
+{% set zulu_build = "11.56.19-ca" %}
+{% set openjdk_revision = "10" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_ppc64le_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-ppc64le"]
-    sha256: d94b6b46a14ab0974b1c1b89661741126d8cf8a0068b471b8f5fa286a71636b1  # [build_platform == "linux-ppc64le"]
+  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_ppc64le_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-ppc64le"]
+    sha256: a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f  # [build_platform == "linux-ppc64le"]
 
-  - url: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_aarch64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-aarch64"]
-    sha256: e9cea040cdf5d9b0a2986feaf87662e1aef68e876f4d66664cb2be36e26db412  # [build_platform == "linux-aarch64"]
+  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_aarch64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-aarch64"]
+    sha256: 999fbd90b070f9896142f0eb28354abbeb367cbe49fd86885c626e2999189e0a  # [build_platform == "linux-aarch64"]
 
-  - url: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_x64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-64"]
-    sha256: e388fd7f3f2503856d0b04fde6e151cbaa91a1df3bcebf1deddfc3729d677ca3  # [build_platform == "linux-64"]
+  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_x64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-64"]
+    sha256: 5fdb4d5a1662f0cca73fec30f99e67662350b1fa61460fa72e91eb9f66b54d0b  # [build_platform == "linux-64"]
 
   - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macosx_x64.zip  # [osx and x86_64]
-    sha256: 45a3d08a6ef21404975433bd8babe4e04c0dbfe8f6e5f34561d89af50b874006  # [osx and x86_64]
+    sha256: a7d68fdf46d88db8b3531035ec1153438b8e519faca0cafd871e6be511ce8be1  # [osx and x86_64]
    
-  - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build_arm64 }}-jdk{{ version }}-macos_aarch64.zip  # [osx and arm64]
-    sha256: 6f0461f2b2448ef7e5e0afe187364588312768bb77e737e90a20e8fc818394ed  # [osx and arm64]
+  - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macos_aarch64.zip  # [osx and arm64]
+    sha256: 43fde6e8291b972146687363b2531dc6e0ba0b18a9f9d66bdad9b88de7403297  # [osx and arm64]
 
   - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-win_x64.zip  # [win64]
-    sha256: b619df7a6f625095ee4adb3add44839b0b1af2adc09a16c7312ca96bb2b61ec9  # [win64]
+    sha256: a106c77389a63b6bd963a087d5f01171bd32aa3ee7377ecef87531390dcb9050  # [win64]
 
   - url: https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip  # [linux]
     sha256: 7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a  # [linux]
     folder: fonts  # [linux]
 
-  - url: https://hg.openjdk.java.net/jdk-updates/jdk{{ version.split(".")[0] }}u/archive/jdk-{{ version }}+{{ openjdk_revision }}.tar.bz2   # [linux]
-    sha256: 1bfcf63e0be8fc37517856e6181b97ed1d83a2436949ad21855ffc6ce14a5a0e  # [linux]
+  - url: https://github.com/openjdk/jdk{{ version.split(".")[0] }}u/archive/refs/tags/jdk-{{ version }}+{{ openjdk_revision}}.zip   # [linux]
+    sha256: b152184f707a0785f93baafbb9382aefdab94cf335b8d7a823160cb2a7a849a3  # [linux]
     folder: src        # [linux]
     patches:           # [linux]
       - fix-arm.patch  # [linux]
 
 build:
-  number: 3
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
AdoptOpenJDK -> Adoptium
https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/

OpenJDK source transition to GitHub

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I updated to the latest version of OpenJDK 11 which is not vulnerable to the [2022/04/19 security advisory](https://openjdk.org/groups/vulnerability/advisories/2022-04-19).

[CVE-2022-21426](https://nvd.nist.gov/vuln/detail/CVE-2022-21426)
[CVE-2022-21434](https://nvd.nist.gov/vuln/detail/CVE-2022-21434)
[CVE-2022-21443](https://nvd.nist.gov/vuln/detail/CVE-2022-21443)
[CVE-2022-21476](https://nvd.nist.gov/vuln/detail/CVE-2022-21476)
[CVE-2022-21496](https://nvd.nist.gov/vuln/detail/CVE-2022-21496)

[AdoptOpenJDK transitioned to Adoptium](https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/).  The newer builds on adoptopenjdk.net forward you to adoptium.net.

The OpenJDK source archives that used to be on their Mercurial server appear to have been transitioned to GitHub.


