### PR TITLE
openjdk 11.0.20

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,8 @@
 
 set -exuo pipefail
 
+JVM_BUILD_LOG_LEVEL=warn
+
 # Remove code signatures from osx-64 binaries as they will be invalidated in the later process.
 # TODO: Fix https://github.com/thefloweringash/sigtool to add --remove-signature support
 if [[ "${target_platform}" == "osx-64" ]]; then
@@ -13,6 +15,10 @@ if [[ "${target_platform}" == "osx-64" ]]; then
   done
   /usr/bin/codesign --remove-signature lib/jspawnhelper
 fi
+
+echo "--------------------------------------------------"
+env | sort
+echo "--------------------------------------------------"
 
 function jdk_install
 {
@@ -46,7 +52,11 @@ function jdk_install
   mkdir -p $INSTALL_DIR/man/man1
   mv man/man1/* $INSTALL_DIR/man/man1
   rm -rf man/man1
-  mv man/* $INSTALL_DIR/man
+
+  # The man dir could be empty already so we can safely ignore this error
+  set +e
+  mv -f man/* $INSTALL_DIR/man
+  set -e
 }
 
 function source_build
@@ -68,16 +78,17 @@ function source_build
 
       export CPATH=$BUILD_PREFIX/include
       export LIBRARY_PATH=$BUILD_PREFIX/lib
-      export CC=${CC_FOR_BUILD}
-      export CXX=${CXX_FOR_BUILD}
-      export CPP=${CXX_FOR_BUILD//+/p}
-      export NM=$($CC_FOR_BUILD -print-prog-name=nm)
-      export AR=$($CC_FOR_BUILD -print-prog-name=ar)
-      export OBJCOPY=$($CC_FOR_BUILD -print-prog-name=objcopy)
-      export STRIP=$($CC_FOR_BUILD -print-prog-name=strip)
+      _TOOLCHAIN_ARGS="CC=${CC_FOR_BUILD} CXX=${CXX_FOR_BUILD} CPP=${CXX_FOR_BUILD//+/p}"
+      _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS AR=$BUILD_PREFIX/bin/$BUILD-ar"
+      _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_CXXFILT=$BUILD_PREFIX/bin/$BUILD-c++filt"
+      _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS NM=$BUILD_PREFIX/bin/$BUILD-nm"
+      _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS OBJCOPY=$BUILD_PREFIX/bin/$BUILD-objcopy"
+      _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS OBJDUMP=$BUILD_PREFIX/bin/$BUILD-objdump"
+      _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS READELF=$BUILD_PREFIX/bin/$BUILD-readelf"
+      _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS STRIP=$BUILD_PREFIX/bin/$BUILD-strip"
       export PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig
 
-      # CFLAGS and CXXFLAGS are intentionally empty
+      # CFLAGS, CXXFLAGS are intentionally empty
       export -n CFLAGS
       export -n CXXFLAGS
       unset CPPFLAGS
@@ -96,6 +107,7 @@ function source_build
           --with-extra-cflags="${CFLAGS//$PREFIX/$BUILD_PREFIX}" \
           --with-extra-cxxflags="${CXXFLAGS//$PREFIX/$BUILD_PREFIX} -fpermissive" \
           --with-extra-ldflags="${LDFLAGS//$PREFIX/$BUILD_PREFIX}" \
+          --with-log=${JVM_BUILD_LOG_LEVEL} \
           --with-stdc++lib=dynamic \
           --disable-warnings-as-errors \
           --with-x=${BUILD_PREFIX} \
@@ -107,8 +119,9 @@ function source_build
           --with-libjpeg=system \
           --with-lcms=system \
           --with-fontconfig=${BUILD_PREFIX} \
-          --with-boot-jdk=$SRC_DIR/bootjdk
-        make JOBS=$CPU_COUNT images
+          --with-boot-jdk=$SRC_DIR/bootjdk \
+          $_TOOLCHAIN_ARGS
+        make JOBS=$CPU_COUNT $_TOOLCHAIN_ARGS images
       popd
     )
   fi
@@ -116,13 +129,6 @@ function source_build
 
   export CPATH=$PREFIX/include
   export LIBRARY_PATH=$PREFIX/lib
-  export BUILD_CC=${CC_FOR_BUILD}
-  export BUILD_CXX=${CXX_FOR_BUILD}
-  export BUILD_CPP=${CXX_FOR_BUILD//+/p}
-  export BUILD_NM=$($CC_FOR_BUILD -print-prog-name=nm)
-  export BUILD_AR=$($CC_FOR_BUILD -print-prog-name=ar)
-  export BUILD_OBJCOPY=$($CC_FOR_BUILD -print-prog-name=objcopy)
-  export BUILD_STRIP=$($CC_FOR_BUILD -print-prog-name=strip)
 
   export -n CFLAGS
   export -n CXXFLAGS
@@ -131,7 +137,42 @@ function source_build
   CONFIGURE_ARGS=""
   if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" == 1 ]]; then
     CONFIGURE_ARGS="--with-build-jdk=$SRC_DIR/src/build-build/images/jdk"
+
+    env | sort
+    echo "=================================="
+    echo "RUNNING CROSS COMPILE"
+    echo "=================================="
+
   fi
+
+  function printerror {
+    if [ -f $SRC_DIR/src/build/linux-aarch64-server-release/make-support/failure-logs ]; then
+      cat $SRC_DIR/src/build/linux-aarch64-server-release/make-support/failure-logs
+    fi
+    if [ -f $SRC_DIR/src/build/linux-ppc64le-server-release/make-support/failure-logs ]; then
+      cat $SRC_DIR/src/build/linux-ppc64le-server-release/make-support/failure-logs
+    fi
+    exit 1
+  }
+
+  # We purposefully do NOT include LD here as the openjdk build system resolves that internally from
+  # --build, --host, and --target in conjunction with BUILD_CC and CC
+  _TOOLCHAIN_ARGS="BUILD_CC=${CC_FOR_BUILD} BUILD_CXX=${CXX_FOR_BUILD} BUILD_CPP=${CXX_FOR_BUILD//+/p}"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_AR=$BUILD_PREFIX/bin/$BUILD-ar"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_CXXFILT=$BUILD_PREFIX/bin/$BUILD-c++filt"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_NM=$BUILD_PREFIX/bin/$BUILD-nm"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_OBJCOPY=$BUILD_PREFIX/bin/$BUILD-objcopy"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_OBJDUMP=$BUILD_PREFIX/bin/$BUILD-objdump"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_READELF=$BUILD_PREFIX/bin/$BUILD-readelf"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS BUILD_STRIP=$BUILD_PREFIX/bin/$BUILD-strip"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS CC=${CC} CXX=${CXX} CPP=${CXX//+/p}"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS AR=$BUILD_PREFIX/bin/$HOST-ar"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS CXXFILT=$BUILD_PREFIX/bin/$HOST-c++filt"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS NM=$BUILD_PREFIX/bin/$HOST-nm"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS OBJCOPY=$BUILD_PREFIX/bin/$HOST-objcopy"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS OBJDUMP=$BUILD_PREFIX/bin/$HOST-objdump"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS READELF=$BUILD_PREFIX/bin/$HOST-readelf"
+  _TOOLCHAIN_ARGS="$_TOOLCHAIN_ARGS STRIP=$BUILD_PREFIX/bin/$HOST-strip"
 
   ./configure \
     --prefix=$PREFIX \
@@ -141,6 +182,7 @@ function source_build
     --with-extra-cflags="$CFLAGS" \
     --with-extra-cxxflags="$CXXFLAGS -fpermissive" \
     --with-extra-ldflags="$LDFLAGS" \
+    --with-log=${JVM_BUILD_LOG_LEVEL} \
     --with-x=$PREFIX \
     --with-cups=$PREFIX \
     --with-freetype=system \
@@ -153,10 +195,12 @@ function source_build
     --with-stdc++lib=dynamic \
     --disable-warnings-as-errors \
     --with-boot-jdk=$SRC_DIR/bootjdk \
-    ${CONFIGURE_ARGS}
+    --disable-javac-server \
+    ${CONFIGURE_ARGS} \
+    $_TOOLCHAIN_ARGS
 
-  make JOBS=$CPU_COUNT
-  make JOBS=$CPU_COUNT images
+  make JOBS=$CPU_COUNT $_TOOLCHAIN_ARGS || printerror
+  make JOBS=$CPU_COUNT images $_TOOLCHAIN_ARGS || printerror
 }
 
 if [[ "$target_platform" == linux* ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,9 @@
-{% set name = "openjdk" %}
 {% set version = "11.0.15" %}
 {% set zulu_build = "11.56.19-ca" %}
 {% set openjdk_revision = "10" %}
 
 package:
-  name: {{ name|lower }}
+  name: openjdk
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,45 @@
 {% set version = "11.0.15" %}
-{% set zulu_build = "11.56.19-ca" %}
 {% set openjdk_revision = "10" %}
+{% set zulu_build = "11.56.19-ca" %}
+
+{% set major = version.split(".")[0] %}
+{% set jdk_full = version ~ "+" ~ openjdk_revision %}
+
+{% set temurin_url = "https://github.com/adoptium/temurin" ~ major ~ "-binaries/releases/download" %}
+{% set temurin_base =  "jdk-" ~ jdk_full ~ "/OpenJDK" ~ major ~ "U-jdk" %}
+{% set temurin_suffix = "linux_hotspot_" ~ jdk_full.replace("+", "_") ~ ".tar.gz" %}
+
+{% set zulu_url = "https://cdn.azul.com/zulu/bin" %}
+{% set zulu_base = "zulu" ~ zulu_build ~ "-jdk" ~ version %}
 
 package:
   name: openjdk
   version: {{ version }}
 
 source:
-  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_x64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-64"]
+  - url: {{ temurin_url }}/{{ temurin_base }}_x64_{{ temurin_suffix }}        # [build_platform == "linux-64"]
     sha256: 5fdb4d5a1662f0cca73fec30f99e67662350b1fa61460fa72e91eb9f66b54d0b  # [build_platform == "linux-64"]
-
-  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_aarch64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-aarch64"]
+  # native compilation: currently unused
+  - url: {{ temurin_url }}/{{ temurin_base }}_aarch64_{{ temurin_suffix }}    # [build_platform == "linux-aarch64"]
     sha256: 999fbd90b070f9896142f0eb28354abbeb367cbe49fd86885c626e2999189e0a  # [build_platform == "linux-aarch64"]
-
-  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_ppc64le_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-ppc64le"]
+  - url: {{ temurin_url }}/{{ temurin_base }}_ppc64le_{{ temurin_suffix }}    # [build_platform == "linux-ppc64le"]
     sha256: a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f  # [build_platform == "linux-ppc64le"]
 
-  - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macosx_x64.zip  # [osx and x86_64]
-    sha256: a7d68fdf46d88db8b3531035ec1153438b8e519faca0cafd871e6be511ce8be1  # [osx and x86_64]
-   
-  - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macosx_aarch64.zip  # [osx and arm64]
-    sha256: 43fde6e8291b972146687363b2531dc6e0ba0b18a9f9d66bdad9b88de7403297  # [osx and arm64]
-
-  - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-win_x64.zip  # [win64]
-    sha256: a106c77389a63b6bd963a087d5f01171bd32aa3ee7377ecef87531390dcb9050  # [win64]
-
+  - url: https://github.com/openjdk/jdk{{ major }}u/archive/refs/tags/jdk-{{ jdk_full }}.zip                    # [linux]
+    sha256: b152184f707a0785f93baafbb9382aefdab94cf335b8d7a823160cb2a7a849a3  # [linux]
+    folder: src                                                               # [linux]
+    patches:                                                                  # [linux]
+      - fix-arm.patch                                                         # [linux]
   - url: https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip  # [linux]
     sha256: 7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a  # [linux]
-    folder: fonts  # [linux]
+    folder: fonts                                                             # [linux]
 
-  - url: https://github.com/openjdk/jdk{{ version.split(".")[0] }}u/archive/refs/tags/jdk-{{ version }}+{{ openjdk_revision }}.zip   # [linux]
-    sha256: b152184f707a0785f93baafbb9382aefdab94cf335b8d7a823160cb2a7a849a3  # [linux]
-    folder: src        # [linux]
-    patches:           # [linux]
-      - fix-arm.patch  # [linux]
+  - url: {{ zulu_url }}/{{ zulu_base }}-macosx_x64.zip                        # [osx and x86_64]
+    sha256: a7d68fdf46d88db8b3531035ec1153438b8e519faca0cafd871e6be511ce8be1  # [osx and x86_64]
+  - url: {{ zulu_url }}/{{ zulu_base }}-macosx_aarch64.zip                    # [osx and arm64]
+    sha256: 43fde6e8291b972146687363b2531dc6e0ba0b18a9f9d66bdad9b88de7403297  # [osx and arm64]
+  - url: {{ zulu_url }}/{{ zulu_base }}-win_x64.zip                           # [win64]
+    sha256: a106c77389a63b6bd963a087d5f01171bd32aa3ee7377ecef87531390dcb9050  # [win64]
 
 build:
   number: 7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,14 +7,14 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_ppc64le_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-ppc64le"]
-    sha256: a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f  # [build_platform == "linux-ppc64le"]
+  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_x64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-64"]
+    sha256: 5fdb4d5a1662f0cca73fec30f99e67662350b1fa61460fa72e91eb9f66b54d0b  # [build_platform == "linux-64"]
 
   - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_aarch64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-aarch64"]
     sha256: 999fbd90b070f9896142f0eb28354abbeb367cbe49fd86885c626e2999189e0a  # [build_platform == "linux-aarch64"]
 
-  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_x64_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-64"]
-    sha256: 5fdb4d5a1662f0cca73fec30f99e67662350b1fa61460fa72e91eb9f66b54d0b  # [build_platform == "linux-64"]
+  - url: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-{{ version }}+{{ openjdk_revision }}/OpenJDK11U-jdk_ppc64le_linux_hotspot_{{ version }}_{{ openjdk_revision }}.tar.gz   # [build_platform == "linux-ppc64le"]
+    sha256: a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f  # [build_platform == "linux-ppc64le"]
 
   - url: https://cdn.azul.com/zulu/bin/zulu{{ zulu_build }}-jdk{{ version }}-macosx_x64.zip  # [osx and x86_64]
     sha256: a7d68fdf46d88db8b3531035ec1153438b8e519faca0cafd871e6be511ce8be1  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "11.0.15" %}
-{% set openjdk_revision = "10" %}
-{% set zulu_build = "11.56.19-ca" %}
+{% set version = "11.0.20" %}
+{% set openjdk_revision = "8" %}
+{% set zulu_build = "11.66.15-ca" %}
 
 {% set major = version.split(".")[0] %}
 {% set jdk_full = version ~ "+" ~ openjdk_revision %}
@@ -18,15 +18,15 @@ package:
 
 source:
   - url: {{ temurin_url }}/{{ temurin_base }}_x64_{{ temurin_suffix }}        # [build_platform == "linux-64"]
-    sha256: 5fdb4d5a1662f0cca73fec30f99e67662350b1fa61460fa72e91eb9f66b54d0b  # [build_platform == "linux-64"]
+    sha256: 7a99258af2e3ee9047e90f1c0c1775fd6285085759501295358d934d662e01f9  # [build_platform == "linux-64"]
   # native compilation: currently unused
   - url: {{ temurin_url }}/{{ temurin_base }}_aarch64_{{ temurin_suffix }}    # [build_platform == "linux-aarch64"]
     sha256: 999fbd90b070f9896142f0eb28354abbeb367cbe49fd86885c626e2999189e0a  # [build_platform == "linux-aarch64"]
   - url: {{ temurin_url }}/{{ temurin_base }}_ppc64le_{{ temurin_suffix }}    # [build_platform == "linux-ppc64le"]
     sha256: a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f  # [build_platform == "linux-ppc64le"]
 
-  - url: https://github.com/openjdk/jdk{{ major }}u/archive/refs/tags/jdk-{{ jdk_full }}.zip                    # [linux]
-    sha256: b152184f707a0785f93baafbb9382aefdab94cf335b8d7a823160cb2a7a849a3  # [linux]
+  - url: https://github.com/openjdk/jdk{{ major }}u/archive/refs/tags/jdk-{{ jdk_full }}.tar.gz                 # [linux]
+    sha256: b2a37ef209ae7eaf8f34182b7c9aa3252af20a214d02970f96ce62242c805479  # [linux]
     folder: src                                                               # [linux]
     patches:                                                                  # [linux]
       - fix-arm.patch                                                         # [linux]
@@ -35,14 +35,14 @@ source:
     folder: fonts                                                             # [linux]
 
   - url: {{ zulu_url }}/{{ zulu_base }}-macosx_x64.zip                        # [osx and x86_64]
-    sha256: a7d68fdf46d88db8b3531035ec1153438b8e519faca0cafd871e6be511ce8be1  # [osx and x86_64]
+    sha256: 20cbb825705cc0353e3640643e50f2c83827334ded5e9bae91cd4656ef2e7f11  # [osx and x86_64]
   - url: {{ zulu_url }}/{{ zulu_base }}-macosx_aarch64.zip                    # [osx and arm64]
-    sha256: 43fde6e8291b972146687363b2531dc6e0ba0b18a9f9d66bdad9b88de7403297  # [osx and arm64]
+    sha256: d07f8c734e377fe527792d3a082cd50c5119840b9cadc660691df3a950fd2981  # [osx and arm64]
   - url: {{ zulu_url }}/{{ zulu_base }}-win_x64.zip                           # [win64]
-    sha256: a106c77389a63b6bd963a087d5f01171bd32aa3ee7377ecef87531390dcb9050  # [win64]
+    sha256: 43408193ce2fa0862819495b5ae8541085b95660153f2adcf91a52d3a1710e83  # [win64]
 
 build:
-  number: 7
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
openjdk is at 11.0.21+5 [already](https://github.com/openjdk/jdk11u/tags), but
* https://github.com/adoptium/temurin11-binaries/releases is only at 11.0.20.1+1
* https://cdn.azul.com/zulu/bin/ is only at 11.0.20