### PR TITLE
[java11] Don't depend on libcxx; unpin compilers on ppc; fix deps on windows

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,9 +1,5 @@
 alsa_lib:
 - 1.2.10
-c_compiler:
-- gcc
-c_compiler_version:
-- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -30,8 +26,5 @@ libpng:
 - '1.6'
 target_platform:
 - linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -2,10 +2,6 @@ BUILD:
 - aarch64-conda_cos7-linux-gnu
 alsa_lib:
 - 1.2.10
-c_compiler:
-- gcc
-c_compiler_version:
-- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -34,8 +30,5 @@ libpng:
 - '1.6'
 target_platform:
 - linux-aarch64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,9 +1,5 @@
 alsa_lib:
 - 1.2.10
-c_compiler:
-- gcc
-c_compiler_version:
-- '8'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fontconfig:
@@ -30,8 +26,5 @@ libpng:
 - '1.6'
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,9 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-c_compiler:
-- clang
-c_compiler_version:
-- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -16,8 +12,5 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
 - osx-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,9 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-c_compiler:
-- clang
-c_compiler_version:
-- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -16,8 +12,5 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
 - osx-arm64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,5 +2,7 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2019
 target_platform:
 - win-64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler_version:    # [ppc64le]
-  - '8'                # [ppc64le]
-cxx_compiler_version:  # [ppc64le]
-  - '8'                # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ source:
     sha256: 43408193ce2fa0862819495b5ae8541085b95660153f2adcf91a52d3a1710e83  # [win64]
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     # the produced artefacts still need libc++.*.dylib on osx,
     # but the one in the platform sdk is enough; avoid extra run-export

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,10 @@ source:
 
 build:
   number: 0
+  ignore_run_exports:
+    # the produced artefacts still need libc++.*.dylib on osx,
+    # but the one in the platform sdk is enough; avoid extra run-export
+    - libcxx  # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,8 @@ build:
 
 requirements:
   build:
-    # We also need a compiler on osx to produce correct signatures
-    - {{ compiler('cxx') }}   # [not win]
+    # for strong run-exports
+    - {{ compiler("cxx") }}
     - pkg-config        # [linux]
     - autoconf          # [linux]
     - unzip             # [linux]
@@ -90,7 +90,6 @@ requirements:
     - xorg-libxrandr    # [linux]
     - xorg-libxi        # [linux]
     - lcms2             # [linux]
-    - vs2015_runtime    # [win]
   run:
     - xorg-libx11       # [linux]
     - xorg-libxext      # [linux]
@@ -98,7 +97,6 @@ requirements:
     - xorg-libxrender   # [linux]
     - xorg-libxi        # [linux]
     - {{ pin_compatible("alsa-lib", max_pin="x.x.x") }}     # [linux]
-    - vs2015_runtime    # [win]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,16 +104,16 @@ requirements:
 
 test:
   requires:
-    - {{ compiler('c') }}  # [not win]
+    - {{ compiler("cxx") }}  # [unix]
   files:
-    - test-jni  # [not win]
-    - test-jni.sh  # [not win]
-    - test-nio
+    - test-jni.sh
+    - test-jni/
+    - test-nio/
   commands:
     - java -version
-    - '${JAVA_HOME}/bin/java -version'  # [not win]
+    - '$JAVA_HOME/bin/java -version'    # [unix]
     - '%JAVA_HOME%\bin\java -version'   # [win]
-    - ./test-jni.sh  # [not win and not ppc64le]
+    - ./test-jni.sh                     # [unix]
 
 about:
   home: https://www.azul.com/products/zulu/  # [not linux]
@@ -123,7 +123,7 @@ about:
   license_file:
     - LICENSE
     - fonts/LICENSE   # [linux]
-  summary: The Zulu OpenJDK build.           # [not linux]
+  summary: The Zulu OpenJDK build.                    # [not linux]
   summary: An open-source implementation of the JDK   # [linux]
   description: Zulu OpenJDK is an open source build of the Java JDK.   # [not linux]
 


### PR DESCRIPTION
Some cleanups I noticed from staring at this feedstock and its CI