### PR TITLE
Add PowerShell [de]activate scripts

### DIFF
--- a/.ci_support/migrations/harfbuzz10.yaml
+++ b/.ci_support/migrations/harfbuzz10.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for harfbuzz 10
-  kind: version
-  migration_number: 1
-harfbuzz:
-- '10'
-migrator_ts: 1733714243.4949675

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -45,5 +45,8 @@ FOR %%F IN (activate deactivate) DO (
     :: We also copy .sh scripts to be able to use them
     :: with POSIX CLI on Windows.
     copy %RECIPE_DIR%\scripts\%%F-win.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
+    :: Additionally copy .ps1 scripts to work with
+    :: Windows PowerShell
+    copy %RECIPE_DIR%\scripts\%%F.ps1 %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.ps1
     if errorlevel 1 exit 1
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ source:
     sha256: 6cf95de8f5b5d4c5ab64606810796456259a5234e9b170b92879d20aeec79ace  # [win64]
 
 build:
-  number: 0
+  number: 1
   # Binaries are already relocatable and conda-build's post-processing would add a very long RPATH to binaries
   # which doesn't fit anymore into the __LINKEDIT section. For this, we either need to manually reassemble
   # the Mach-O header or build everything from source.

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -1,3 +1,12 @@
 @echo off
-set "JAVA_HOME_CONDA_BACKUP=%JAVA_HOME%"
+rem First, back up the JAVA_HOME variable if it is set.
+rem If it's not set, use the literal string "ENV_VAR_UNSET" as a marker.
+
+if defined JAVA_HOME (
+    set "JAVA_HOME_CONDA_BACKUP=%JAVA_HOME%"
+) else (
+    set "JAVA_HOME_CONDA_BACKUP=ENV_VAR_UNSET"
+)
+
+rem Set JAVA_HOME to the appropriate location for this package.
 set "JAVA_HOME=%CONDA_PREFIX%\Library\lib\jvm"

--- a/recipe/scripts/activate.ps1
+++ b/recipe/scripts/activate.ps1
@@ -1,0 +1,20 @@
+<#
+First backup the variable(s) if they are set.
+Variables are allowed to be empty (indicates unset)
+Then set the variable(s) to the appropriate locations for this package.
+The deactivate script restores the backed up variable(s).
+#>
+
+<#
+NB: we use the literal string "ENV_VAR_UNSET" for a backup to indicate the
+variable was not previously set, as otherwise the backup variable would itself
+be unset and the deactivate script would not be able to tell when to return a
+variable to the unset state.
+#>
+
+if ($env:JAVA_HOME) {
+    $Env:JAVA_HOME_CONDA_BACKUP = "$env:JAVA_HOME"
+} else {
+    $Env:JAVA_HOME_CONDA_BACKUP = "ENV_VAR_UNSET"
+}
+$Env:JAVA_HOME = "$env:CONDA_PREFIX\Library\lib\jvm"

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,3 +1,15 @@
 @echo off
-set "JAVA_HOME=%JAVA_HOME_CONDA_BACKUP%"
-set "JAVA_HOME_CONDA_BACKUP="
+rem First check whether backup variable(s) is/are set.
+rem Variables are allowed to be set empty (indicates unset).
+rem If a backup variable is set, restore it and then unset the backup.
+
+if defined JAVA_HOME_CONDA_BACKUP (
+    rem A literal value of "ENV_VAR_UNSET" indicates the variable was originally
+    rem unset before running the corresponding activate script.
+    if "%JAVA_HOME_CONDA_BACKUP%"=="ENV_VAR_UNSET" (
+        set "JAVA_HOME="
+    ) else (
+        set "JAVA_HOME=%JAVA_HOME_CONDA_BACKUP%"
+    )
+    set "JAVA_HOME_CONDA_BACKUP="
+)

--- a/recipe/scripts/deactivate.ps1
+++ b/recipe/scripts/deactivate.ps1
@@ -1,0 +1,21 @@
+<#
+First check whether backup variable(s) is/are set.
+Variables are allowed to be set empty (indicates unset).
+If a backup variable is set, restore it and then unset the backup.
+#>
+
+<#
+NB: if a backup is set to the literal "ENV_VAR_UNSET", that indicates we must
+unset the corresponding variable. This distinguishes cases where the activate
+script ran but the variable was unset from cases where the activate script has
+not run.
+#>
+
+if ($env:JAVA_HOME_CONDA_BACKUP) {
+    if ($env:JAVA_HOME_CONDA_BACKUP -eq "ENV_VAR_UNSET") {
+        $Env:JAVA_HOME = ""
+    } else {
+        $Env:JAVA_HOME = "$env:JAVA_HOME_CONDA_BACKUP"
+    }
+    $Env:JAVA_HOME_CONDA_BACKUP = ""
+}


### PR DESCRIPTION
This allows `JAVA_HOME` to be [un]set as appropriate when [de]activating a conda environment with OpenJDK.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please add any other relevant info below:
-->

Noticed when debugging [this issue](https://forum.image.sc/t/pyimagej-on-windows-10/107934/18) that OpenJDK doesn't set `JAVA_HOME` on PowerShell.